### PR TITLE
Feature/test login

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -99,6 +99,11 @@
 			<version>5.18.0</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>com.h2database</groupId>
+			<artifactId>h2</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/backend/src/main/java/org/tarjetamish/auth/controller/AuthController.java
+++ b/backend/src/main/java/org/tarjetamish/auth/controller/AuthController.java
@@ -3,7 +3,7 @@ package org.tarjetamish.auth.controller;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import org.tarjetamish.account.dto.request.LoginRequestDTO;
+import org.tarjetamish.auth.dto.request.LoginRequestDTO;
 import org.tarjetamish.auth.service.IAuthService;
 import java.util.Map;
 
@@ -19,9 +19,5 @@ public class AuthController {
         return ResponseEntity.ok(Map.of("token", token));
     }
 
-    @GetMapping("/test")
-    public ResponseEntity<String> test() {
-        return ResponseEntity.ok("Test endpoint");
-    }
 }
     

--- a/backend/src/main/java/org/tarjetamish/auth/dto/request/LoginRequestDTO.java
+++ b/backend/src/main/java/org/tarjetamish/auth/dto/request/LoginRequestDTO.java
@@ -1,2 +1,2 @@
-package org.tarjetamish.account.dto.request;
+package org.tarjetamish.auth.dto.request;
 public record LoginRequestDTO(String rut, int pin) {}

--- a/backend/src/main/java/org/tarjetamish/auth/dto/request/UserRegisterDTO.java
+++ b/backend/src/main/java/org/tarjetamish/auth/dto/request/UserRegisterDTO.java
@@ -1,4 +1,4 @@
-package org.tarjetamish.account.dto.request;
+package org.tarjetamish.auth.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;

--- a/backend/src/main/java/org/tarjetamish/auth/service/AuthServiceImpl.java
+++ b/backend/src/main/java/org/tarjetamish/auth/service/AuthServiceImpl.java
@@ -4,7 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.java.Log;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
-import org.tarjetamish.account.dto.request.UserRegisterDTO;
+import org.tarjetamish.auth.dto.request.UserRegisterDTO;
 import org.tarjetamish.auth.exception.InvalidCredentialsException;
 import org.tarjetamish.auth.exception.UserAlreadyExistException;
 import org.tarjetamish.auth.exception.UserNotFoundException;

--- a/backend/src/main/java/org/tarjetamish/auth/service/IAuthService.java
+++ b/backend/src/main/java/org/tarjetamish/auth/service/IAuthService.java
@@ -1,6 +1,6 @@
 package org.tarjetamish.auth.service;
 
-import org.tarjetamish.account.dto.request.UserRegisterDTO;
+import org.tarjetamish.auth.dto.request.UserRegisterDTO;
 
 public interface IAuthService {
     String login(String rut, int pin);

--- a/backend/src/main/java/org/tarjetamish/user/repository/impl/JdbcUserRepository.java
+++ b/backend/src/main/java/org/tarjetamish/user/repository/impl/JdbcUserRepository.java
@@ -18,37 +18,37 @@ public class JdbcUserRepository implements UserRepository {
     private final UserRowMapper userRowMapper;
     @Override
     public List<User> findAll() {
-        String sql = "SELECT * FROM tarjeta_mish.user";
+        String sql = "SELECT * FROM tarjeta_mish.\"user\"";
         return jdbc.query(sql, userRowMapper);
     }
 
     @Override
     public Optional<User> findById(Long id) {
-        String sql = "SELECT * FROM tarjeta_mish.user WHERE iduser = ?";
+        String sql = "SELECT * FROM tarjeta_mish.\"user\" WHERE iduser = ?";
         return Optional.ofNullable(jdbc.queryForObject(sql, userRowMapper, id));
     }
 
     @Override
     public int save(User user) {
-        String sql = "INSERT INTO tarjeta_mish.user (rut, name, email, pin) VALUES (?, ?, ?, ?)";
+        String sql = "INSERT INTO tarjeta_mish.\"user\" (rut, name, email, pin) VALUES (?, ?, ?, ?)";
         return jdbc.update(sql, user.getRut(), user.getName(), user.getEmail(), user.getPin());
     }
 
     @Override
     public int deleteByRut(String  rut) {
-        String sql = "DELETE FROM tarjeta_mish.user WHERE rut = ?";
+        String sql = "DELETE FROM tarjeta_mish.\"user\" WHERE rut = ?";
         return jdbc.update(sql, rut);
     }
 
     @Override
     public Optional<User> findByRut(String rut) {
-        String sql = "SELECT * FROM tarjeta_mish.user WHERE rut = ?";
+        String sql = "SELECT * FROM tarjeta_mish.\"user\" WHERE rut = ?";
         return Optional.ofNullable(jdbc.queryForObject(sql, userRowMapper, rut));
     }
 
     @Override
     public boolean existByRut(String rut) {
-        String sql = "SELECT COUNT(*) FROM tarjeta_mish.user WHERE rut = ?";
+        String sql = "SELECT COUNT(*) FROM tarjeta_mish.\"user\" WHERE rut = ?";
         Integer count = jdbc.queryForObject(sql, Integer.class, rut);
         return count != null && count > 0;
     }

--- a/backend/src/test/java/org/tarjetamish/auth/integration/AuthIntegrationTest.java
+++ b/backend/src/test/java/org/tarjetamish/auth/integration/AuthIntegrationTest.java
@@ -1,0 +1,54 @@
+package org.tarjetamish.auth.integration;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.*;
+import org.springframework.test.context.ActiveProfiles;
+import org.tarjetamish.user.model.User;
+import org.tarjetamish.user.repository.UserRepository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ActiveProfiles("test")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class AuthIntegrationTest {
+
+    @LocalServerPort
+    int port;
+
+    @Autowired
+    TestRestTemplate restTemplate;
+
+    @Autowired
+    UserRepository userRepository;
+
+    @BeforeEach
+    void setUp() {
+        userRepository.deleteByRut("123456789");
+        User testUser = new User();
+        testUser.setRut("123456789");
+        testUser.setName("Test User");
+        testUser.setEmail("test@test.com");
+        testUser.setPin("1234");
+        userRepository.save(testUser);
+    }
+
+    @Test
+    void login_shouldReturnTokenIfCredentialsAreValid() {
+        String url = "http://localhost:" + port + "/api/auth/login";
+        String body = "{\"rut\":\"123456789\", \"pin\":\"1234\" }";
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        HttpEntity<String> request = new HttpEntity<>(body, headers);
+
+        ResponseEntity<String> response = restTemplate.postForEntity(url, request, String.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).contains("token");
+    }
+}

--- a/backend/src/test/java/org/tarjetamish/auth/service/AuthServiceImplTest.java
+++ b/backend/src/test/java/org/tarjetamish/auth/service/AuthServiceImplTest.java
@@ -1,0 +1,65 @@
+package org.tarjetamish.auth.service;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.tarjetamish.auth.exception.InvalidCredentialsException;
+import org.tarjetamish.auth.exception.UserNotFoundException;
+import org.tarjetamish.auth.jwt.JwtProvider;
+import org.tarjetamish.user.model.User;
+import org.tarjetamish.user.repository.UserRepository;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceImplTest {
+    @Mock
+    UserRepository userRepository;
+    @Mock
+    JwtProvider jwtProvider;
+    @InjectMocks
+    AuthServiceImpl authService;
+
+    @Test
+    void login_success() {
+        String rut = "123456789";
+        int pin = 1234;
+        User user = new User();
+        user.setRut(rut);
+        user.setPin(Integer.toString(pin));
+
+        when(userRepository.findByRut(rut)).thenReturn(Optional.of(user));
+        when(jwtProvider.generateToken(user)).thenReturn("mockedToken");
+
+        String token = authService.login(rut, pin);
+
+        assertEquals("mockedToken", token);
+        verify(jwtProvider).generateToken(user);
+
+    }
+
+    @Test
+    void login_userNotFound() {
+        when(userRepository.findByRut(anyString())).thenReturn(Optional.empty());
+        assertThrows(UserNotFoundException.class, () -> authService.login("invalidRut", 1234));
+    }
+
+    @Test
+    void login_invalidCredentials() {
+        String rut = "123456789";
+        int pin = 1234;
+        User user = new User();
+        user.setRut(rut);
+        user.setPin("4321");
+
+        when(userRepository.findByRut(rut)).thenReturn(Optional.of(user));
+
+        assertThrows(InvalidCredentialsException.class, () -> authService.login(rut, pin));
+    }
+}

--- a/backend/src/test/java/org/tarjetamish/user/controller/UserControllerTest.java
+++ b/backend/src/test/java/org/tarjetamish/user/controller/UserControllerTest.java
@@ -1,4 +1,4 @@
-package org.tarjetamish.controller;
+package org.tarjetamish.user.controller;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/backend/src/test/java/org/tarjetamish/user/repository/UserRepositoryTest.java
+++ b/backend/src/test/java/org/tarjetamish/user/repository/UserRepositoryTest.java
@@ -1,4 +1,4 @@
-package org.tarjetamish.repository;
+package org.tarjetamish.user.repository;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/backend/src/test/java/org/tarjetamish/user/service/UserServiceTest.java
+++ b/backend/src/test/java/org/tarjetamish/user/service/UserServiceTest.java
@@ -1,10 +1,11 @@
-package org.tarjetamish.service;
+package org.tarjetamish.user.service;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.tarjetamish.user.dto.UserDTO;
 import org.tarjetamish.user.service.UserService;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
@@ -22,16 +23,19 @@ public class UserServiceTest {
     void testFindById() {
         assertTrue(userService.findById(1L).isPresent(), "User with ID 1 should exist");
     }
+
     @Test
     void testFindByRut() {
         String rut = "123456789";
         assertTrue(userService.findByRut(rut).isPresent(), "User with RUT " + rut + " should exist");
     }
+
     @Test
     void testSaveUser() {
-        int result = userService.save(new UserDTO(0L,"111111111", "Test", "User", "1234"));
+        int result = userService.save(new UserDTO(0L, "111111111", "Test", "User", "1234"));
         assertEquals(1, result, "User should be saved successfully");
     }
+
     @Test
     void testDeleteUser() {
         String rut = "111111111";

--- a/backend/src/test/resources/application-test.properties
+++ b/backend/src/test/resources/application-test.properties
@@ -1,0 +1,5 @@
+spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.h2.console.enabled=true

--- a/backend/src/test/resources/schema.sql
+++ b/backend/src/test/resources/schema.sql
@@ -1,0 +1,10 @@
+CREATE SCHEMA IF NOT EXISTS tarjeta_mish;
+SET SCHEMA tarjeta_mish;
+
+CREATE TABLE "user" (
+                        iduser BIGINT AUTO_INCREMENT PRIMARY KEY,
+                        rut VARCHAR(9) NOT NULL UNIQUE,
+                        name VARCHAR(60),
+                        email VARCHAR(255),
+                        pin VARCHAR(4) NOT NULL
+);


### PR DESCRIPTION
This pull request introduces several changes to the `backend` project, focusing on restructuring package organization, improving database handling, and adding tests for authentication functionality. Key updates include renaming DTOs and test files, switching to a quoted table name for the `user` table in SQL queries, and adding integration and unit tests for authentication. Additionally, an in-memory H2 database is configured for testing purposes.

### Package and DTO Restructuring:
* Renamed `LoginRequestDTO` and `UserRegisterDTO` files to move them from the `account` package to the `auth` package, reflecting their usage in authentication (`[[1]](diffhunk://#diff-a31f69d56f34b4d840136fd04c7e297a84d3e0d01800cc68af3f8779910980afL1-R1)`, `[[2]](diffhunk://#diff-78de7f74461fb89740acd8ef0db75b46eede2a4f4913d84d855adcec5fe875f1L1-R1)`).
* Updated imports across files to reflect the new package structure for the DTOs (`[[1]](diffhunk://#diff-e0ebe34f7b234a00e66b9d554f43c0a3adfda019dd9dfc508cc18c2c7e51b9d9L6-R6)`, `[[2]](diffhunk://#diff-1e5c34c82b6f6160587c6bd733c90290b5b5e916a30fe51588cdc1ca38bb3dc1L7-R7)`, `[[3]](diffhunk://#diff-1f3ad94c901ce65bc0ca9cf6647e0d74aeba3f69d60ebd7c234a1edb7a587c96L3-R3)`).

### Database Handling Improvements:
* Updated SQL queries in `JdbcUserRepository` to use quoted table names (`"user"`) for compatibility with reserved keywords in SQL (`[backend/src/main/java/org/tarjetamish/user/repository/impl/JdbcUserRepository.javaL21-R51](diffhunk://#diff-5e817abdcdc3a84d304a95b801998fe1ef39984edb2e1b776ad89d06b7583802L21-R51)`).
* Configured an H2 in-memory database for testing, including schema creation in `schema.sql` and connection settings in `application-test.properties` (`[[1]](diffhunk://#diff-5afb134304db01d489869e1e30f73e9d4d283282685d1d96c423f163b1666a5dR1-R5)`, `[[2]](diffhunk://#diff-331b8e798fe103e8d93e287dec14993aaf1f4956a03e6e828d29a96b3f222f71R1-R10)`).

### Authentication Testing:
* Added `AuthIntegrationTest` to validate the login endpoint with integration tests (`[backend/src/test/java/org/tarjetamish/auth/integration/AuthIntegrationTest.javaR1-R54](diffhunk://#diff-b72d8c25ecfbe7de0c8ff70807934ff0f7dc86a5078d5e045a50f5bc773e0fe6R1-R54)`).
* Added `AuthServiceImplTest` to cover unit testing for login functionality, including success, user-not-found, and invalid credentials scenarios (`[backend/src/test/java/org/tarjetamish/auth/service/AuthServiceImplTest.javaR1-R65](diffhunk://#diff-648eaf9763840687fbe4c3aa07b728807198dacb053ca7c7a2d2ba9e3ca46d51R1-R65)`).

### Test File Renaming:
* Renamed test files for `UserController`, `UserRepository`, and `UserService` to align with their corresponding packages (`[[1]](diffhunk://#diff-c205e5d7718c08bd77d1d24de673601f6589d5b19ae55ea08259df1982e09b6cL1-R1)`, `[[2]](diffhunk://#diff-516d898774ff091d87724dd7a842ec12e7ef665783c1946f96460d4c8d6ca912L1-R1)`, `[[3]](diffhunk://#diff-a91045b77f7ef3d082e2c5956e478f2019afa890468c12b4049fbbb5d5e3f15eL1-R8)`).

### Minor Cleanup:
* Removed an unused `/test` endpoint from `AuthController` to clean up the codebase (`[backend/src/main/java/org/tarjetamish/auth/controller/AuthController.javaL22-L25](diffhunk://#diff-e0ebe34f7b234a00e66b9d554f43c0a3adfda019dd9dfc508cc18c2c7e51b9d9L22-L25)`).