### PR TITLE
Feature/register

### DIFF
--- a/backend/src/main/java/org/tarjetamish/auth/dto/request/UserRegisterDTO.java
+++ b/backend/src/main/java/org/tarjetamish/auth/dto/request/UserRegisterDTO.java
@@ -2,8 +2,11 @@ package org.tarjetamish.auth.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
+import org.tarjetamish.common.annotations.Rut;
+
 public record UserRegisterDTO (
         @NotBlank(message = "Rut is mandatory")
+        @Rut
         String rut,
 
         @NotBlank(message = "Name is mandatory")

--- a/backend/src/main/java/org/tarjetamish/common/annotations/Rut.java
+++ b/backend/src/main/java/org/tarjetamish/common/annotations/Rut.java
@@ -1,0 +1,19 @@
+package org.tarjetamish.common.annotations;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import org.tarjetamish.common.annotations.validator.RutValidator;
+
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = RutValidator.class)
+@Target({ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Rut {
+String message() default "Invalid RUT format";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/backend/src/main/java/org/tarjetamish/common/annotations/validator/RutValidator.java
+++ b/backend/src/main/java/org/tarjetamish/common/annotations/validator/RutValidator.java
@@ -1,0 +1,40 @@
+package org.tarjetamish.common.annotations.validator;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import org.tarjetamish.common.annotations.Rut;
+
+public class RutValidator implements ConstraintValidator<Rut, String> {
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        if (value == null || value.isBlank()) return false;
+
+        String rut = value.replaceAll("[^0-9Kk]", "").toUpperCase();
+
+        if (!rut.matches("\\d{7,8}[0-9K]")) return false;
+
+
+        String body = rut.substring(0, rut.length() - 1);
+        char checkDigit = rut.charAt(rut.length() - 1);
+
+        int sum = 0;
+        int factor = 2;
+
+        for (int i = body.length() - 1; i >= 0; i--) {
+            sum += Character.getNumericValue(body.charAt(i)) * factor;
+            factor = factor == 7 ? 2 : factor + 1;
+        }
+
+        int remainder = 11 - (sum % 11);
+        char expectedCheckDigit;
+
+        switch (remainder) {
+            case 11 -> expectedCheckDigit = '0';
+            case 10 -> expectedCheckDigit = 'K';
+            default -> expectedCheckDigit = (char) ('0' + remainder);
+        }
+
+        return checkDigit == expectedCheckDigit;
+    }
+}

--- a/backend/src/test/java/org/tarjetamish/common/RutValidatorTest.java
+++ b/backend/src/test/java/org/tarjetamish/common/RutValidatorTest.java
@@ -1,0 +1,33 @@
+package org.tarjetamish.common;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+import org.tarjetamish.common.annotations.validator.RutValidator;
+
+class RutValidatorTest {
+
+    private final RutValidator validator = new RutValidator();
+
+    @Test
+    void testValidRut() {
+        assertTrue(validator.isValid("216801830", null));
+        assertTrue(validator.isValid("21.680.183-0", null));
+        assertTrue(validator.isValid("21680183-0", null));
+    }
+
+    @Test
+    void testInvalidRut() {
+        assertFalse(validator.isValid("1234567", null));
+        assertFalse(validator.isValid("1234567890", null));
+        assertFalse(validator.isValid("12345678A", null));
+        assertFalse(validator.isValid("11111111K", null));
+    }
+
+    @Test
+    void testEmptyRut() {
+        assertFalse(validator.isValid("", null));
+        assertFalse(validator.isValid(null, null));
+    }
+}
+


### PR DESCRIPTION
This pull request introduces a new custom annotation, `@Rut`, for validating Chilean RUT (Rol Único Tributario) format in user registration, along with its implementation and associated tests. The most important changes are grouped into the addition of the annotation, its validator, and unit tests.

### Addition of `@Rut` annotation:
* [`backend/src/main/java/org/tarjetamish/common/annotations/Rut.java`](diffhunk://#diff-1d0559ef925a5a10ac651b547ff34d90d3a329c2ff41a2f04757764b4b37a42fR1-R19): Created the `@Rut` annotation for validating RUT format, specifying the validation logic through the `RutValidator` class.
* [`backend/src/main/java/org/tarjetamish/auth/dto/request/UserRegisterDTO.java`](diffhunk://#diff-78de7f74461fb89740acd8ef0db75b46eede2a4f4913d84d855adcec5fe875f1R5-R9): Applied the `@Rut` annotation to the `rut` field in the `UserRegisterDTO` class to enforce RUT validation during user registration.

### Implementation of RUT validation logic:
* [`backend/src/main/java/org/tarjetamish/common/annotations/validator/RutValidator.java`](diffhunk://#diff-e5369cfa46d469029057c27476c7a64d823297ed1c3684a5824ad0af0e22724fR1-R40): Implemented the `RutValidator` class to validate RUT format, including support for check digit calculation and ignoring formatting characters (e.g., dots and dashes).

### Unit tests for RUT validation:
* [`backend/src/test/java/org/tarjetamish/common/RutValidatorTest.java`](diffhunk://#diff-7353c2fb2264e8fab8cd7fada5aa9727df8b78257170bd6d96651cedc64478e5R1-R33): Added unit tests for `RutValidator` to verify valid RUTs, invalid RUTs, and edge cases like empty or null values.