### PR TITLE
Revert "feat: findByIdAccount"

### DIFF
--- a/backend/src/main/java/org/tarjetamish/transaction/controller/TransactionController.java
+++ b/backend/src/main/java/org/tarjetamish/transaction/controller/TransactionController.java
@@ -26,10 +26,6 @@ public class TransactionController {
                 .map(ResponseEntity::ok)
                 .orElse(ResponseEntity.notFound().build());
     }
-    @GetMapping("/account/{idAccount}")
-    public ResponseEntity<List<TransactionDTO>> getTransactionsByAccountId(@PathVariable int idAccount) {
-        return ResponseEntity.ok(transactionService.findByIdAccount(idAccount));
-    }
 
     @PostMapping
     public ResponseEntity<Integer> createTransaction(@RequestBody TransactionDTO transactionDTO) {

--- a/backend/src/main/java/org/tarjetamish/transaction/repository/TransactionRepository.java
+++ b/backend/src/main/java/org/tarjetamish/transaction/repository/TransactionRepository.java
@@ -10,8 +10,6 @@ public interface TransactionRepository {
 
     Optional<Transaction> findById(Long id);
 
-    List<Transaction> findByIdAccount(int idUser);
-
     int save(Transaction transaction);
 
     int deleteById(Long id);

--- a/backend/src/main/java/org/tarjetamish/transaction/repository/impl/JdbcTransactionRepository.java
+++ b/backend/src/main/java/org/tarjetamish/transaction/repository/impl/JdbcTransactionRepository.java
@@ -27,11 +27,6 @@ public class JdbcTransactionRepository implements TransactionRepository {
         String sql = "SELECT * FROM tarjeta_mish.movement WHERE idmovement = ?";
         return Optional.ofNullable(jdbc.queryForObject(sql, transactionRowMapper, id));
     }
-    @Override
-    public List<Transaction> findByIdAccount(int idAccount) {
-        String sql = "SELECT * FROM tarjeta_mish.movement WHERE idaccount = ?";
-        return jdbc.query(sql, transactionRowMapper, idAccount);
-    }
 
     @Override
     public int save(Transaction transaction) {

--- a/backend/src/main/java/org/tarjetamish/transaction/service/TransactionService.java
+++ b/backend/src/main/java/org/tarjetamish/transaction/service/TransactionService.java
@@ -26,11 +26,6 @@ public class TransactionService {
     public Optional<TransactionDTO> findById(Long id) {
         return Optional.ofNullable(transactionRepository.findById(id).map(transactionConverter::toTransactionDTO).orElseThrow(TransactionNotFoundException::new));
     }
-    public List<TransactionDTO> findByIdAccount(int idUser) {
-        return transactionRepository.findByIdAccount(idUser).stream()
-                .map(transactionConverter::toTransactionDTO)
-                .toList();
-    }
 
     public int save(TransactionDTO transactionDTO) {
         return transactionRepository.save(transactionConverter.toTransaction(transactionDTO));


### PR DESCRIPTION
This pull request removes the functionality for retrieving transactions by account ID from the backend. The changes affect the controller, repository, and service layers by removing the associated methods and queries.

### Removal of "Get Transactions by Account ID" functionality:

* [`backend/src/main/java/org/tarjetamish/transaction/controller/TransactionController.java`](diffhunk://#diff-109dc6fc3fb9a8353775fbf47e8af0cc1dbfe33299aa64ce28b942af5d1a4869L29-L32): Deleted the `getTransactionsByAccountId` endpoint, which was responsible for fetching transactions by account ID.
* [`backend/src/main/java/org/tarjetamish/transaction/repository/TransactionRepository.java`](diffhunk://#diff-a4007c44bacf3b2143252a92c51ff106728915b264bee8b1c0fd97ed43febdc2L13-L14): Removed the `findByIdAccount` method from the repository interface.
* [`backend/src/main/java/org/tarjetamish/transaction/repository/impl/JdbcTransactionRepository.java`](diffhunk://#diff-8541ef6a331f761e01d72e51a650ba2a3e24676b2aa59a1524c18e372e70d97fL30-L34): Deleted the implementation of the `findByIdAccount` method, including the SQL query for retrieving transactions by account ID.
* [`backend/src/main/java/org/tarjetamish/transaction/service/TransactionService.java`](diffhunk://#diff-5204ac32bb9119a1512743bcb42e3321d97810202317be438444fe37c32e99e6L29-L33): Removed the `findByIdAccount` method from the service layer, which handled the business logic for fetching transactions by account ID.