### PR TITLE
Change pin type from int to String in auth flow

### DIFF
--- a/backend/src/main/java/org/tarjetamish/auth/dto/request/LoginRequestDTO.java
+++ b/backend/src/main/java/org/tarjetamish/auth/dto/request/LoginRequestDTO.java
@@ -1,2 +1,2 @@
 package org.tarjetamish.auth.dto.request;
-public record LoginRequestDTO(String rut, int pin) {}
+public record LoginRequestDTO(String rut, String pin) {}

--- a/backend/src/main/java/org/tarjetamish/auth/service/AuthServiceImpl.java
+++ b/backend/src/main/java/org/tarjetamish/auth/service/AuthServiceImpl.java
@@ -29,10 +29,10 @@ public class AuthServiceImpl implements IAuthService {
     private final RegisterUtils registerUtils;
 
     @Override
-    public String login(String rut, int pin) {
+    public String login(String rut, String pin) {
         User user = userRepository.findByRut(rut)
                 .orElseThrow(() -> new UserNotFoundException(rut));
-        if (String.valueOf(pin).equals(String.valueOf(user.getPin()))) {
+        if (pin.equals(user.getPin())) {
             return jwtProvider.generateToken(user);
         }
         throw new InvalidCredentialsException("Invalid credentials");

--- a/backend/src/main/java/org/tarjetamish/auth/service/IAuthService.java
+++ b/backend/src/main/java/org/tarjetamish/auth/service/IAuthService.java
@@ -3,7 +3,7 @@ package org.tarjetamish.auth.service;
 import org.tarjetamish.auth.dto.request.UserRegisterDTO;
 
 public interface IAuthService {
-    String login(String rut, int pin);
+    String login(String rut, String pin);
 
     boolean validateSession(String token);
 

--- a/backend/src/test/java/org/tarjetamish/auth/service/AuthServiceImplTest.java
+++ b/backend/src/test/java/org/tarjetamish/auth/service/AuthServiceImplTest.java
@@ -29,10 +29,10 @@ class AuthServiceImplTest {
     @Test
     void login_success() {
         String rut = "123456789";
-        int pin = 1234;
+        String pin = "1234";
         User user = new User();
         user.setRut(rut);
-        user.setPin(Integer.toString(pin));
+        user.setPin(pin);
 
         when(userRepository.findByRut(rut)).thenReturn(Optional.of(user));
         when(jwtProvider.generateToken(user)).thenReturn("mockedToken");
@@ -47,13 +47,13 @@ class AuthServiceImplTest {
     @Test
     void login_userNotFound() {
         when(userRepository.findByRut(anyString())).thenReturn(Optional.empty());
-        assertThrows(UserNotFoundException.class, () -> authService.login("invalidRut", 1234));
+        assertThrows(UserNotFoundException.class, () -> authService.login("invalidRut", "1234"));
     }
 
     @Test
     void login_invalidCredentials() {
         String rut = "123456789";
-        int pin = 1234;
+        String pin = "1234";
         User user = new User();
         user.setRut(rut);
         user.setPin("4321");


### PR DESCRIPTION
This pull request updates the `pin` field in the authentication module from an `int` to a `String` to allow for more flexible handling of PIN formats. The changes span the DTO, service interface, service implementation, and associated test cases.

### Authentication Module Updates:

* [`backend/src/main/java/org/tarjetamish/auth/dto/request/LoginRequestDTO.java`](diffhunk://#diff-a31f69d56f34b4d840136fd04c7e297a84d3e0d01800cc68af3f8779910980afL2-R2): Changed the `pin` field type from `int` to `String` in the `LoginRequestDTO` record.
* [`backend/src/main/java/org/tarjetamish/auth/service/IAuthService.java`](diffhunk://#diff-1f3ad94c901ce65bc0ca9cf6647e0d74aeba3f69d60ebd7c234a1edb7a587c96L6-R6): Updated the `login` method signature to accept `String` for the `pin` parameter instead of `int`.
* [`backend/src/main/java/org/tarjetamish/auth/service/AuthServiceImpl.java`](diffhunk://#diff-1e5c34c82b6f6160587c6bd733c90290b5b5e916a30fe51588cdc1ca38bb3dc1L32-R35): Updated the `login` method implementation to handle `pin` as a `String` and adjusted the equality check accordingly.

### Test Case Updates:

* [`backend/src/test/java/org/tarjetamish/auth/service/AuthServiceImplTest.java`](diffhunk://#diff-648eaf9763840687fbe4c3aa07b728807198dacb053ca7c7a2d2ba9e3ca46d51L32-R35): Updated test cases (`login_success`, `login_userNotFound`, and `login_invalidCredentials`) to use `String` for the `pin` field and adjusted mock setups and assertions accordingly. [[1]](diffhunk://#diff-648eaf9763840687fbe4c3aa07b728807198dacb053ca7c7a2d2ba9e3ca46d51L32-R35) [[2]](diffhunk://#diff-648eaf9763840687fbe4c3aa07b728807198dacb053ca7c7a2d2ba9e3ca46d51L50-R56)Updated the pin field in LoginRequestDTO, IAuthService, AuthServiceImpl, and related tests to use String instead of int. This change allows for more flexible pin formats and resolves type inconsistencies in the authentication process.