### PR TITLE
Use password encoder for PIN verification in login

### DIFF
--- a/backend/src/main/java/org/tarjetamish/auth/service/AuthServiceImpl.java
+++ b/backend/src/main/java/org/tarjetamish/auth/service/AuthServiceImpl.java
@@ -32,7 +32,7 @@ public class AuthServiceImpl implements IAuthService {
     public String login(String rut, String pin) {
         User user = userRepository.findByRut(rut)
                 .orElseThrow(() -> new UserNotFoundException(rut));
-        if (pin.equals(user.getPin())) {
+        if (passwordEncoder.matches(pin, user.getPin())) {
             return jwtProvider.generateToken(user);
         }
         throw new InvalidCredentialsException("Invalid credentials");


### PR DESCRIPTION
This pull request includes a security improvement to the login functionality in the `AuthServiceImpl` class. The change replaces plain-text PIN comparison with a hashed password verification mechanism.

### Security improvement:

* [`backend/src/main/java/org/tarjetamish/auth/service/AuthServiceImpl.java`](diffhunk://#diff-1e5c34c82b6f6160587c6bd733c90290b5b5e916a30fe51588cdc1ca38bb3dc1L35-R35): Updated the login method to use `passwordEncoder.matches()` for comparing the provided PIN with the stored hashed PIN, enhancing security by preventing plain-text PIN storage and comparison.Replaced direct PIN comparison with passwordEncoder.matches to securely verify user PINs during login. This enhances authentication security by supporting hashed PIN storage.